### PR TITLE
Adds "files" query param to Vimeo video API calls

### DIFF
--- a/src/gateways/Vimeo.php
+++ b/src/gateways/Vimeo.php
@@ -170,7 +170,7 @@ class Vimeo extends Gateway
     {
         $data = $this->get('videos/'.$id, [
             'query' => [
-                'fields' => 'created_time,description,duration,height,link,name,pictures,pictures,privacy,stats,uri,user,width,download,review_link'
+                'fields' => 'created_time,description,duration,height,link,name,pictures,pictures,privacy,stats,uri,user,width,download,review_link,files'
             ],
         ]);
 


### PR DESCRIPTION
Vimeo Business and PRO members have access to the direct links of their converted video files, which can be used to play videos in a `<video>` tag, without the need for a Vimeo embed.

Adding the "files" query param will add an array of direct links to the API response.

This is preferred to the direct links found in the `download` block of an API response because those direct links expire, which could lead to issues if the response is cached for longer than the link’s expiration date.

Additionally, unlike the "download" param, the direct links returned from the "files" param include an HLS (HTTP Live Streaming) version of the video, which is supported on iOS Safari and Android Chrome.