### PR TITLE
Updates example config with correct handle for YouTube gateway

### DIFF
--- a/src/config/videos.example.php
+++ b/src/config/videos.example.php
@@ -22,7 +22,7 @@ return [
      * OAuth provider options.
      */
     'oauthProviderOptions' => [
-        'google' => [
+        'youtube' => [
             'clientId' => 'OAUTH_CLIENT_ID',
             'clientSecret' => 'OAUTH_CLIENT_SECRET'
         ],


### PR DESCRIPTION
Hey @benjamindavid.

Was configuring oauth creds for YouTube and found creds under the `google` handle weren't being picked up. I did a little digging and found that the name of the handle is actually `youtube`.

This PR simply changes the example config to reflect that.

In the long term, I'd like to see [environmental configuration](https://docs.craftcms.com/v3/config/environments.html) as the primary way of handling Video oauth creds. (see issue #18)

I'm not much of a PHP dev, but would be more than happy to help implement environmental config for these fields. Currently, these sensitive creds are making their way into git via `project.yaml`.

Thanks!