### PR TITLE
Fixed issue #25 and added duration in ISO 8601

### DIFF
--- a/src/gateways/Vimeo.php
+++ b/src/gateways/Vimeo.php
@@ -10,6 +10,7 @@ namespace dukt\videos\gateways;
 use dukt\videos\base\Gateway;
 use dukt\videos\errors\CollectionParsingException;
 use dukt\videos\errors\VideoNotFoundException;
+use dukt\videos\helpers\VideosHelper;
 use dukt\videos\models\Collection;
 use dukt\videos\models\Section;
 use dukt\videos\models\Video;
@@ -476,7 +477,6 @@ class Vimeo extends Gateway
         $video->authorName = $data['user']['name'];
         $video->authorUrl = $data['user']['link'];
         $video->date = new DateTime($data['created_time']);
-        $video->durationSeconds = $data['duration'];
         $video->description = $data['description'];
         $video->gatewayHandle = 'vimeo';
         $video->gatewayName = 'Vimeo';
@@ -486,6 +486,10 @@ class Vimeo extends Gateway
         $video->url = 'https://vimeo.com/'.substr($data['uri'], 8);
         $video->width = $data['width'];
         $video->height = $data['height'];
+
+        // Video duration
+        $video->durationSeconds = $data['duration'];
+        $video->duration8601 = VideosHelper::getDuration8601($data['duration']);
 
         $this->parsePrivacy($video, $data);
         $this->parseThumbnails($video, $data);

--- a/src/gateways/YouTube.php
+++ b/src/gateways/YouTube.php
@@ -612,7 +612,8 @@ class YouTube extends Gateway
 
         // Video Duration
         $interval = new \DateInterval($data['contentDetails']['duration']);
-        $video->durationSeconds = (int) $interval->format('%s');
+        $video->durationSeconds = (int) date_create('@0')->add($interval)->getTimestamp();
+        $video->duration8601 = $data['contentDetails']['duration'];
 
         // Thumbnails
         $video->thumbnailSource = $this->getThumbnailSource($data['snippet']['thumbnails']);

--- a/src/helpers/VideosHelper.php
+++ b/src/helpers/VideosHelper.php
@@ -46,6 +46,34 @@ class VideosHelper
     }
 
     /**
+     * Formats seconds to ISO 8601 duration
+     *
+     * @param $seconds
+     *
+     * @return string
+     */
+    public function getDuration8601($seconds): string
+    {
+        $hours = (int)((int)$seconds / 3600);
+        $minutes = (($seconds / 60) % 60);
+        $seconds %= 60;
+
+        $iso8601 = 'PT';
+
+        if ($hours > 0) {
+            $iso8601 .= "{$hours}H";
+        }
+
+        if ($minutes > 0) {
+            $iso8601 .= "{$minutes}M";
+        }
+
+        $iso8601 .= "{$seconds}S";
+
+        return $iso8601;
+    }
+
+    /**
      * Returns a video thumbnail’s published URL.
      *
      * @param $gatewayHandle

--- a/src/models/Video.php
+++ b/src/models/Video.php
@@ -69,6 +69,11 @@ class Video extends Model
     public $durationSeconds;
 
     /**
+     * @var int|null Duration of the video in ISO 8601 format
+     */
+    public $duration8601;
+
+    /**
      * @var string|null The author’s name
      */
     public $authorName;


### PR DESCRIPTION
Fixed issue #25, which was due to the fact that `format('%s')` returns only second units, rather than converting the complete duration into seconds.

Also added `duration8601` property to video model. This is useful because [structured data for videos](https://developers.google.com/search/docs/data-types/video) requires the duration of the video be formatted in ISO 8601.

Can you please merge these? Thanks!