### PR TITLE
Implement iframe title attribute

### DIFF
--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -232,6 +232,7 @@ abstract class Gateway implements GatewayInterface
     public function getEmbedHtml($videoId, array $options = []): string
     {
         $embedAttributes = [
+            'title' => 'External video from' . $this->getHandle(),
             'frameborder' => '0',
             'allowfullscreen' => 'true',
             'allowscriptaccess' => 'true',
@@ -243,6 +244,12 @@ abstract class Gateway implements GatewayInterface
         if (!$disableSize) {
             $this->parseEmbedAttribute($embedAttributes, $options, 'width', 'width');
             $this->parseEmbedAttribute($embedAttributes, $options, 'height', 'height');
+        }
+
+        $title = $options['title'] ?? false;
+
+        if($title) {
+            $this->parseEmbedAttribute($embedAttributes, $options, 'title', 'title');
         }
 
         $this->parseEmbedAttribute($embedAttributes, $options, 'iframeClass', 'class');


### PR DESCRIPTION
Implements the ability to set the title attribute and custom value for accessibility purposes. This can then be wired up to the `video.embed` in twig to point to a field in Craft CMS if required.

I set a default title value for validation purposes.

Relates to #30 