### PR TITLE
Fix Cache Duration Preference Being Ignored

### DIFF
--- a/src/services/Cache.php
+++ b/src/services/Cache.php
@@ -11,6 +11,7 @@ use Craft;
 use dukt\videos\Plugin as VideosPlugin;
 use yii\base\Component;
 use DateInterval;
+use DateTimeImmutable;
 
 /**
  * Class Cache service.
@@ -61,9 +62,11 @@ class Cache extends Component
             $cacheKey = $this->getCacheKey($id);
 
             if (!$expire) {
-                $expire = VideosPlugin::$plugin->getSettings()->cacheDuration;
-                $expire = new DateInterval($expire);
-                $expire = $expire->format('%s');
+                $duration = VideosPlugin::$plugin->getSettings()->cacheDuration;
+                $interval = new DateInterval($duration);
+                $now = new DateTimeImmutable();
+                $expiryDate = $now->add($interval);
+                $expire = $expiryDate->getTimestamp() - $now->getTimestamp();
             }
 
             return Craft::$app->cache->set($cacheKey, $value, $expire, $dependency);

--- a/src/services/Cache.php
+++ b/src/services/Cache.php
@@ -11,7 +11,7 @@ use Craft;
 use dukt\videos\Plugin as VideosPlugin;
 use yii\base\Component;
 use DateInterval;
-use DateTimeImmutable;
+use craft\helpers\DateTimeHelper;
 
 /**
  * Class Cache service.
@@ -64,9 +64,7 @@ class Cache extends Component
             if (!$expire) {
                 $duration = VideosPlugin::$plugin->getSettings()->cacheDuration;
                 $interval = new DateInterval($duration);
-                $now = new DateTimeImmutable();
-                $expiryDate = $now->add($interval);
-                $expire = $expiryDate->getTimestamp() - $now->getTimestamp();
+                $expire = DateTimeHelper::intervalToSeconds($interval);
             }
 
             return Craft::$app->cache->set($cacheKey, $value, $expire, $dependency);

--- a/src/services/Videos.php
+++ b/src/services/Videos.php
@@ -74,7 +74,7 @@ class Videos extends Component
      * @return bool|mixed|null
      * @throws \yii\base\InvalidConfigException
      */
-    public function getVideoByUrl($videoUrl, $enableCache = true, $cacheExpiry = 3600)
+    public function getVideoByUrl($videoUrl, $enableCache = true, $cacheExpiry = null)
     {
         $video = $this->requestVideoByUrl($videoUrl, $enableCache, $cacheExpiry);
 
@@ -99,7 +99,7 @@ class Videos extends Component
      * @return \dukt\videos\models\Video|mixed
      * @throws \yii\base\InvalidConfigException
      */
-    private function requestVideoById($gatewayHandle, $id, $enableCache = true, $cacheExpiry = 3600)
+    private function requestVideoById($gatewayHandle, $id, $enableCache = true, $cacheExpiry = null)
     {
         $enableCache = VideosPlugin::$plugin->getSettings()->enableCache === false ? false : $enableCache;
 
@@ -134,7 +134,7 @@ class Videos extends Component
      * @return bool|mixed
      * @throws \yii\base\InvalidConfigException
      */
-    private function requestVideoByUrl($videoUrl, $enableCache = true, $cacheExpiry = 3600)
+    private function requestVideoByUrl($videoUrl, $enableCache = true, $cacheExpiry = null)
     {
         $key = 'videos.video.'.md5($videoUrl);
         $enableCache = VideosPlugin::$plugin->getSettings()->enableCache === false ? false : $enableCache;

--- a/src/web/twig/variables/VideosVariable.php
+++ b/src/web/twig/variables/VideosVariable.php
@@ -38,7 +38,7 @@ class VideosVariable
      *
      * @return bool|null
      */
-    public function getVideoByUrl($videoUrl, $enableCache = true, $cacheExpiry = 3600)
+    public function getVideoByUrl($videoUrl, $enableCache = true, $cacheExpiry = null)
     {
         try {
             return Videos::$plugin->getVideos()->getVideoByUrl($videoUrl, $enableCache, $cacheExpiry);
@@ -56,7 +56,7 @@ class VideosVariable
      * @param bool $enableCache
      * @param int  $cacheExpiry
      */
-    public function url($videoUrl, $enableCache = true, $cacheExpiry = 3600)
+    public function url($videoUrl, $enableCache = true, $cacheExpiry = null)
     {
         $this->getVideoByUrl($videoUrl, $enableCache, $cacheExpiry);
     }


### PR DESCRIPTION
As it stands, the cache duration preference is superseded by default parameters throughout this plugin. Since we call for this preference in the set method, it's redundant to set these as default parameters, and actually blocks the preference, leaving the preference itself inert. This PR fixes that.

There was also an issue in the cache logic (presumably because you never actually hit this code whilst developing!) whereby it would only extract the `%s` component from the interval. `->format('%s')` does not convert the duration to seconds, it simply extracts the seconds from your input. So if I use your default value of `PT15M`, the value here would be `0` since I didn't specify in seconds. Using this new code, I can specify `P1Y` and it gets converted and set correctly.