### PR TITLE
Vimeo: Plugin not loading due to missing "stats" value

### DIFF
--- a/src/gateways/Vimeo.php
+++ b/src/gateways/Vimeo.php
@@ -492,7 +492,7 @@ class Vimeo extends Gateway
         $collection['id'] = substr($data['uri'], strpos($data['uri'], '/albums/') + \strlen('/albums/'));
         $collection['url'] = $data['uri'];
         $collection['title'] = $data['name'];
-        $collection['totalVideos'] = $data['stats']['videos'];
+        $collection['totalVideos'] = $data['stats']['videos'] ?? 0;
 
         return $collection;
     }
@@ -524,7 +524,7 @@ class Vimeo extends Gateway
         $collection['id'] = substr($data['uri'], strpos($data['uri'], '/channels/') + \strlen('/channels/'));
         $collection['url'] = $data['uri'];
         $collection['title'] = $data['name'];
-        $collection['totalVideos'] = $data['stats']['videos'];
+        $collection['totalVideos'] = $data['stats']['videos'] ?? 0;
 
         return $collection;
     }


### PR DESCRIPTION
The selection screen for vimeo appears to be broken, the following error is thrown:

```
Undefined array key "stats"
```

I'm not sure about the underlying issue, but at first glance this appears to fix it.