### PR TITLE
Get vimeo urls directly from API to support unlisted videos

### DIFF
--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -14,6 +14,7 @@ use dukt\videos\errors\ApiResponseException;
 use dukt\videos\errors\GatewayMethodNotFoundException;
 use dukt\videos\errors\JsonParsingException;
 use dukt\videos\errors\VideoNotFoundException;
+use dukt\videos\models\Video;
 use dukt\videos\Plugin as Videos;
 use dukt\videos\Plugin;
 use dukt\videos\records\Token as TokenRecord;
@@ -218,12 +219,12 @@ abstract class Gateway implements GatewayInterface
     /**
      * Returns the HTML of the embed from a video ID.
      *
-     * @param       $videoId
+     * @param Video $video
      * @param array $options
      *
      * @return string
      */
-    public function getEmbedHtml($videoId, array $options = []): string
+    public function getEmbedHtml(Video $video, array $options = []): string
     {
         $embedAttributes = [
             'title' => 'External video from ' . $this->getHandle(),
@@ -248,7 +249,7 @@ abstract class Gateway implements GatewayInterface
 
         $this->parseEmbedAttribute($embedAttributes, $options, 'iframeClass', 'class');
 
-        $embedUrl = $this->getEmbedUrl($videoId, $options);
+        $embedUrl = $this->getEmbedUrl($video, $options);
 
         $embedAttributesString = '';
 
@@ -262,28 +263,28 @@ abstract class Gateway implements GatewayInterface
     /**
      * Returns the URL of the embed from a video ID.
      *
-     * @param       $videoId
+     * @param Video $video
      * @param array $options
      *
      * @return string
      */
-    public function getEmbedUrl($videoId, array $options = []): string
+    public function getEmbedUrl(Video $video, array $options = []): string
     {
-        $format = $this->getEmbedFormat();
+        $embedUrl = $video->embedUrl ?: sprintf($this->getEmbedFormat(), $video->id);
 
         if ($options !== []) {
             $queryMark = '?';
 
-            if (strpos($this->getEmbedFormat(), '?') !== false) {
+            if (strpos($embedUrl, '?') !== false) {
                 $queryMark = '&';
             }
 
             $options = http_build_query($options);
 
-            $format .= $queryMark . $options;
+            $embedUrl .= $queryMark . $options;
         }
 
-        return sprintf($format, $videoId);
+        return $embedUrl;
     }
 
     /**

--- a/src/gateways/Vimeo.php
+++ b/src/gateways/Vimeo.php
@@ -196,7 +196,7 @@ class Vimeo extends Gateway
     {
         $data = $this->get('videos/' . $id, [
             'query' => [
-                'fields' => 'created_time,description,duration,height,link,name,pictures,pictures,privacy,stats,uri,user,width,download,review_link,files'
+                'fields' => 'created_time,description,duration,height,link,name,pictures,pictures,player_embed_url,privacy,stats,uri,user,width,download,review_link,files'
             ],
         ]);
 
@@ -569,7 +569,8 @@ class Vimeo extends Gateway
         $video->id = (int)substr($data['uri'], \strlen('/videos/'));
         $video->plays = $data['stats']['plays'] ?? 0;
         $video->title = $data['name'];
-        $video->url = 'https://vimeo.com/' . substr($data['uri'], 8);
+        $video->url = $data['link'];
+        $video->embedUrl = $data['player_embed_url'];
         $video->width = $data['width'];
         $video->height = $data['height'];
 
@@ -662,7 +663,7 @@ class Vimeo extends Gateway
     private function performVideosRequest($uri, array $params): array
     {
         $query = $this->queryFromParams($params);
-        $query['fields'] = 'created_time,description,duration,height,link,name,pictures,pictures,privacy,stats,uri,user,width,download,review_link,files';
+        $query['fields'] = 'created_time,description,duration,height,link,name,pictures,pictures,player_embed_url,privacy,stats,uri,user,width,download,review_link,files';
 
         $data = $this->get($uri, [
             'query' => $query

--- a/src/models/Video.php
+++ b/src/models/Video.php
@@ -44,6 +44,11 @@ class Video extends Model
     public $url;
 
     /**
+     * @var string|null The embed URL of the video
+     */
+    public $embedUrl;
+
+    /**
      * @var string|null The gateway’s handle
      */
     public $gatewayHandle;
@@ -152,7 +157,7 @@ class Video extends Model
      */
     public function getEmbed(array $opts = []): Twig_Markup
     {
-        $embed = $this->getGateway()->getEmbedHtml($this->id, $opts);
+        $embed = $this->getGateway()->getEmbedHtml($this, $opts);
         $charset = Craft::$app->getView()->getTwig()->getCharset();
 
         return new Twig_Markup($embed, $charset);
@@ -174,7 +179,7 @@ class Video extends Model
             return null;
         }
 
-        return $gateway->getEmbedUrl($this->id, $opts);
+        return $gateway->getEmbedUrl($this, $opts);
     }
 
     /**


### PR DESCRIPTION
Unlisted Vimeo videos cannot be embedded using just their ID; [the hash has to be included in the URL](https://help.vimeo.com/hc/en-us/articles/12426470858001-Embedded-player-displays-This-video-does-not-exist-message).

Instead of trying to parse the URL from the Vimeo API and then re-create an embed URL that can be used in Craft,
I modified the `Gateway::getEmbedUrl()` method to take the `Video` object and use a new property `embedUrl` if set.

I made the `Vimeo` gateway set the `embedUrl` from the `player_embed_url` provided by the Vimeo API, which includes the hash for unlisted videos. 

I also made the `Vimeo` gateway set the `url` directly from the `link` provided by the Vimeo API, which includes the hash for unlisted vidoes.

For other gateways like `Youtube` the old behavior should be preserved