### PR TITLE
Remove Youtube broad scope

### DIFF
--- a/src/gateways/YouTube.php
+++ b/src/gateways/YouTube.php
@@ -75,7 +75,6 @@ class YouTube extends Gateway
         return [
             'https://www.googleapis.com/auth/userinfo.profile',
             'https://www.googleapis.com/auth/userinfo.email',
-            'https://www.googleapis.com/auth/youtube',
             'https://www.googleapis.com/auth/youtube.readonly'
         ];
     }


### PR DESCRIPTION
The scope removed was asking the user permissions to manage the FULL Youtube account and that was not needed. In fact the read.only scope is more than enough to get the permission token to view the user plugin. The extra scope has been removed because when submitting a custom google app for verification, Google will complain of this large scope (and this also gives too much power to this plugin, with the risk of compromising the youtube account of the user).

Please see the permissions asked to the user:

![scopes-highlight](https://github.com/dukt/videos/assets/128366984/84f479cc-df6a-481a-85cd-2d0ad361c390)
